### PR TITLE
Update README for Laravel 13 and PHP 8.3+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   [![Total Downloads](https://img.shields.io/packagist/dt/grazulex/laravel-chronotrace.svg?style=flat-square)](https://packagist.org/packages/grazulex/laravel-chronotrace)
   [![License](https://img.shields.io/github/license/grazulex/laravel-chronotrace.svg?style=flat-square)](https://github.com/Grazulex/laravel-chronotrace/blob/main/LICENSE.md)
   [![PHP Version](https://img.shields.io/badge/php-8.3%2B-777bb4?style=flat-square&logo=php)](https://php.net/)
-  [![Laravel Version](https://img.shields.io/badge/laravel-12.x-ff2d20?style=flat-square&logo=laravel)](https://laravel.com/)
+  [![Laravel Version](https://img.shields.io/badge/laravel-12.x%20|%2013.x-ff2d20?style=flat-square&logo=laravel)](https://laravel.com/)
   [![Tests](https://img.shields.io/github/actions/workflow/status/grazulex/laravel-chronotrace/tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/Grazulex/laravel-chronotrace/actions)
   [![Code Style](https://img.shields.io/badge/code%20style-pint-000000?style=flat-square&logo=laravel)](https://github.com/laravel/pint)
 </div>
@@ -49,7 +49,7 @@ composer require --dev grazulex/laravel-chronotrace
 
 **Requirements:**
 - PHP 8.3+
-- Laravel 12.x
+- Laravel 12.x / 13.x
 
 ---
 


### PR DESCRIPTION
## Summary

- Update Laravel version badge from `12.x` to `12.x | 13.x`
- Update Requirements section to mention `Laravel 12.x / 13.x`

Follows #12 which added the actual compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)